### PR TITLE
Add removal controls and stats for implementation changes

### DIFF
--- a/src/components/TraycerWorkspace.tsx
+++ b/src/components/TraycerWorkspace.tsx
@@ -42,6 +42,7 @@ export function TraycerWorkspace({ workspace }: TraycerWorkspaceProps) {
             onAddManualChange={workspace.addManualChange}
             onUpdateChange={workspace.updateCodeChange}
             onUpdateChangeStatus={workspace.updateCodeChangeStatus}
+            onRemoveChange={workspace.removeCodeChange}
           />
         </section>
         <section className="workspace__section" id="review">

--- a/src/components/implementation/ImplementationPanel.css
+++ b/src/components/implementation/ImplementationPanel.css
@@ -109,6 +109,29 @@
   gap: 0.75rem;
 }
 
+.change-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.change-card__remove {
+  border: none;
+  background: none;
+  color: rgba(248, 113, 113, 0.85);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.25rem;
+  border-radius: 0.4rem;
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.change-card__remove:hover,
+.change-card__remove:focus-visible {
+  color: rgba(248, 113, 113, 1);
+  background: rgba(248, 113, 113, 0.12);
+}
+
 .change-card__file {
   border-radius: 0.55rem;
   border: 1px solid rgba(148, 163, 184, 0.25);

--- a/src/components/implementation/ImplementationPanel.tsx
+++ b/src/components/implementation/ImplementationPanel.tsx
@@ -25,6 +25,7 @@ interface ImplementationPanelProps {
   ) => void;
   onUpdateChange: (id: string, patch: Partial<Omit<CodeChange, 'id'>>) => void;
   onUpdateChangeStatus: (id: string, status: CodeChangeStatus) => void;
+  onRemoveChange: (id: string) => void;
 }
 
 export function ImplementationPanel({
@@ -32,7 +33,8 @@ export function ImplementationPanel({
   onSeedChanges,
   onAddManualChange,
   onUpdateChange,
-  onUpdateChangeStatus
+  onUpdateChangeStatus,
+  onRemoveChange
 }: ImplementationPanelProps) {
   const [showManualForm, setShowManualForm] = useState(false);
   const [manualDraft, setManualDraft] = useState<ManualChangeDraft>({
@@ -51,7 +53,8 @@ export function ImplementationPanel({
     const total = task.changes.length;
     const ready = task.changes.filter((change) => change.status === 'ready').length;
     const draft = task.changes.filter((change) => change.status === 'draft').length;
-    return { total, ready, draft };
+    const inReview = task.changes.filter((change) => change.status === 'in-review').length;
+    return { total, ready, draft, inReview };
   }, [task.changes]);
 
   const handleManualSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -91,6 +94,7 @@ export function ImplementationPanel({
           <span>Total: {stats.total}</span>
           <span>Ready: {stats.ready}</span>
           <span>Draft: {stats.draft}</span>
+          <span>In review: {stats.inReview}</span>
         </div>
       </div>
 
@@ -161,7 +165,16 @@ export function ImplementationPanel({
                       ))}
                     </select>
                   </div>
-                  <span className={`badge badge--${change.status}`}>{change.status}</span>
+                  <div className="change-card__status">
+                    <span className={`badge badge--${change.status}`}>{change.status}</span>
+                    <button
+                      type="button"
+                      className="change-card__remove"
+                      onClick={() => onRemoveChange(change.id)}
+                    >
+                      Remove change
+                    </button>
+                  </div>
                 </header>
 
                 <label className="change-card__field">

--- a/src/components/task/TaskOverview.tsx
+++ b/src/components/task/TaskOverview.tsx
@@ -16,7 +16,7 @@ export function TaskOverview({ task, sections }: TaskOverviewProps) {
   }, [task.plan]);
 
   return (
-    <div className="task-overview">
+    <div className="task-overview" id="overview">
       <div className="task-overview__header">
         <h1>{task.title}</h1>
         <p>{task.prompt}</p>

--- a/src/hooks/useTraycerWorkspace.ts
+++ b/src/hooks/useTraycerWorkspace.ts
@@ -28,6 +28,7 @@ export interface TraycerWorkspaceApi {
   }) => void;
   updateCodeChange: (changeId: string, patch: Partial<Omit<CodeChange, 'id'>>) => void;
   updateCodeChangeStatus: (changeId: string, status: CodeChangeStatus) => void;
+  removeCodeChange: (changeId: string) => void;
   runReview: (options?: ReviewRunOptions) => void;
   toggleReviewResolved: (reviewId: string) => void;
   clearWorkspace: () => void;
@@ -119,6 +120,13 @@ export function useTraycerWorkspace(): TraycerWorkspaceApi {
     updateCodeChange(changeId, { status });
   }, [updateCodeChange]);
 
+  const removeCodeChange = useCallback((changeId: string) => {
+    setTask((current) => ({
+      ...current,
+      changes: current.changes.filter((change) => change.id !== changeId)
+    }));
+  }, []);
+
   const runReview = useCallback((options?: ReviewRunOptions) => {
     setTask((current) => ({
       ...current,
@@ -153,6 +161,7 @@ export function useTraycerWorkspace(): TraycerWorkspaceApi {
       addManualChange,
       updateCodeChange,
       updateCodeChangeStatus,
+      removeCodeChange,
       runReview,
       toggleReviewResolved,
       clearWorkspace
@@ -165,6 +174,7 @@ export function useTraycerWorkspace(): TraycerWorkspaceApi {
       addManualChange,
       updateCodeChange,
       updateCodeChangeStatus,
+      removeCodeChange,
       runReview,
       toggleReviewResolved,
       clearWorkspace


### PR DESCRIPTION
## Summary
- expose a workspace API to remove code changes and pass it into the implementation panel
- add remove actions, in-review stats, and styling updates for implementation change cards
- anchor the overview section for navigation links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0096a2120832c957a5f9487c4160e