### PR TITLE
Highlight automated test validation in planning panel

### DIFF
--- a/src/components/common/badge.css
+++ b/src/components/common/badge.css
@@ -39,3 +39,8 @@
   background: rgba(250, 204, 21, 0.18);
   color: #fde68a;
 }
+
+.badge--required {
+  background: rgba(244, 63, 94, 0.18);
+  color: #fda4af;
+}

--- a/src/components/planning/PlanningPanel.css
+++ b/src/components/planning/PlanningPanel.css
@@ -100,6 +100,10 @@
   gap: 0.9rem;
 }
 
+.plan-list__validation {
+  list-style: none;
+}
+
 .plan-list__step {
   display: flex;
   align-items: flex-start;
@@ -109,6 +113,21 @@
   border-radius: 0.9rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(30, 41, 59, 0.55);
+}
+
+.plan-list__step--validation {
+  border-style: dashed;
+  background: rgba(13, 148, 136, 0.18);
+}
+
+.plan-list__step--validation h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.plan-list__status--validation {
+  align-items: flex-end;
 }
 
 .plan-list__copy h3 {

--- a/src/components/planning/PlanningPanel.tsx
+++ b/src/components/planning/PlanningPanel.tsx
@@ -125,6 +125,21 @@ export function PlanningPanel({ task, onGeneratePlan, onUpdatePlanStepStatus }: 
             </div>
           </li>
         ))}
+        <li className="plan-list__validation">
+          <div className="plan-list__step plan-list__step--validation">
+            <div className="plan-list__copy">
+              <h3>Validate with automated tests</h3>
+              <p>
+                Ensure new behaviour is covered by automated tests and capture the validation notes alongside the
+                implementation changes before marking the work ready for review.
+              </p>
+            </div>
+            <div className="plan-list__status plan-list__status--validation">
+              <span>Expectation</span>
+              <span className="badge badge--required">Always</span>
+            </div>
+          </div>
+        </li>
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a dedicated validation bullet in the planning panel to emphasise automated test coverage expectations
- style the validation note to stand out and label it as a required step

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e00edae6b4832cab7bcb189e5401eb