### PR TITLE
Add validation reminders to planning, implementation, and review panels

### DIFF
--- a/src/components/implementation/ImplementationPanel.css
+++ b/src/components/implementation/ImplementationPanel.css
@@ -31,6 +31,32 @@
   color: rgba(148, 163, 184, 0.9);
 }
 
+.implementation-validation {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(45, 212, 191, 0.35);
+  background: rgba(15, 118, 110, 0.12);
+  padding: 1rem 1.1rem;
+  color: rgba(226, 232, 240, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.implementation-validation h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.implementation-validation ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 .manual-change {
   display: flex;
   flex-direction: column;

--- a/src/components/implementation/ImplementationPanel.tsx
+++ b/src/components/implementation/ImplementationPanel.tsx
@@ -141,6 +141,17 @@ export function ImplementationPanel({
         </div>
       </div>
 
+      <div className="implementation-validation" role="note">
+        <h3>Validation expectations</h3>
+        <ul>
+          <li>
+            Link each ready change to the automated tests (unit, integration, or end-to-end) that now exercise the new
+            behaviour.
+          </li>
+          <li>Record any manual verification performed so reviewers can double-check critical paths.</li>
+        </ul>
+      </div>
+
       {showManualForm ? (
         <form className="manual-change" onSubmit={handleManualSubmit}>
           <div className="manual-change__row">

--- a/src/components/planning/PlanningPanel.css
+++ b/src/components/planning/PlanningPanel.css
@@ -234,6 +234,19 @@
   background: rgba(22, 163, 74, 0.2);
 }
 
+.plan-timeline__item--validation {
+  border-style: dashed;
+  border-color: rgba(45, 212, 191, 0.55);
+  background: rgba(15, 118, 110, 0.18);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.plan-timeline__item--validation .plan-timeline__index {
+  background: rgba(20, 184, 166, 0.45);
+  color: #0f172a;
+  font-weight: 700;
+}
+
 .plan-timeline__index {
   display: inline-flex;
   align-items: center;
@@ -255,6 +268,11 @@
 
 .plan-timeline__title {
   font-weight: 600;
+}
+
+.plan-timeline__note {
+  font-size: 0.7rem;
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .plan-timeline__blocked {

--- a/src/components/planning/PlanningPanel.tsx
+++ b/src/components/planning/PlanningPanel.tsx
@@ -126,6 +126,17 @@ export function PlanningPanel({ task, aiState, onGeneratePlan, onUpdatePlanStepS
               </div>
             </li>
           ))}
+          <li className="plan-timeline__item plan-timeline__item--validation">
+            <span className="plan-timeline__index" aria-hidden>
+              QA
+            </span>
+            <div className="plan-timeline__copy">
+              <span className="plan-timeline__title">Document automated test coverage</span>
+              <span className="plan-timeline__note">
+                Capture which automated tests protect the change and log any manual validation notes before review.
+              </span>
+            </div>
+          </li>
         </ol>
       ) : null}
 

--- a/src/components/review/ReviewPanel.css
+++ b/src/components/review/ReviewPanel.css
@@ -65,6 +65,32 @@
   color: rgba(148, 163, 184, 0.9);
 }
 
+.review-validation {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(30, 64, 175, 0.12);
+  padding: 0.95rem 1.1rem;
+  color: rgba(226, 232, 240, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.review-validation h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.review-validation ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .review-list {
   list-style: none;
   margin: 0;

--- a/src/components/review/ReviewPanel.tsx
+++ b/src/components/review/ReviewPanel.tsx
@@ -88,6 +88,14 @@ export function ReviewPanel({ task, aiState, onRunReview, onToggleResolved, onMa
         </div>
       ) : null}
 
+      <div className="review-validation" role="note">
+        <h3>Before requesting review</h3>
+        <ul>
+          <li>Confirm the relevant automated test suites pass locally or in CI.</li>
+          <li>Summarise any exploratory or manual testing in the change log for reviewer visibility.</li>
+        </ul>
+      </div>
+
       <div className="review-toolbar">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- add a dedicated QA entry to the planning timeline that captures automated test coverage and validation notes
- surface validation expectations within the implementation and review panels via contextual callouts

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e018e3d70c832c91679344e5863d23